### PR TITLE
Saber project x 2021.2.2f1. HDCamera exposure

### DIFF
--- a/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/Exposure.compute
+++ b/com.unity.render-pipelines.high-definition/Runtime/PostProcessing/Shaders/Exposure.compute
@@ -2,6 +2,7 @@
 
 #pragma only_renderers d3d11 playstation xboxone xboxseries vulkan metal switch
 
+#pragma kernel KDecodeExposure
 #pragma kernel KFixedExposure
 #pragma kernel KManualCameraExposure
 #pragma kernel KPrePass
@@ -9,10 +10,21 @@
 #pragma kernel KReset
 
 TEXTURE2D(_InputTexture);
+RWBuffer<float> _OutputExposure;
 
 #define PREPASS_TEX_SIZE 1024.0
 #define PREPASS_TEX_HALF_SIZE 512.0
 //#pragma enable_d3d11_debug_symbols
+
+//
+// Decode exposure from texture
+//
+[numthreads(1,1,1)]
+void KDecodeExposure(uint2 dispatchThreadId : SV_DispatchThreadID)
+{
+    _OutputExposure[0] = _InputTexture[dispatchThreadId].x;
+    _OutputExposure[1] = _InputTexture[dispatchThreadId].y;
+}
 
 //
 // Fixed exposure

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/Camera/HDCamera.cs
@@ -113,6 +113,9 @@ namespace UnityEngine.Rendering.HighDefinition
         /// <summary>Current time for this camera.</summary>
         public float time; // Take the 'animateMaterials' setting into account.
 
+        /// <summary>Last calculated exposure from post-processing.</summary>
+        public float lastExposure { get; internal set; }
+
         internal bool dofHistoryIsValid = false;  // used to invalidate DoF accumulation history when switching DoF modes
 
         // State needed to handle TAAU.

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDProfileId.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDProfileId.cs
@@ -197,6 +197,7 @@ namespace UnityEngine.Rendering.HighDefinition
         FixedExposure,
         DynamicExposure,
         ApplyExposure,
+        UpdateLastExposure,
         TemporalAntialiasing,
         DeepLearningSuperSamplingColorMask,
         DeepLearningSuperSampling,

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.PostProcess.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.PostProcess.cs
@@ -1345,6 +1345,44 @@ namespace UnityEngine.Rendering.HighDefinition
             return source;
         }
 
+        class UpdateLastExposureData
+        {
+            public ComputeShader applyExposureCS;
+
+            public int decodeExposureKernel;
+            public ComputeBufferHandle exposureBuffer;
+            public TextureHandle exposureToDecode;
+
+            public HDCamera hdCamera;
+        }
+
+        void UpdateCameraLastExposure(RenderGraph renderGraph, HDCamera hdCamera)
+        {
+            using (var builder = renderGraph.AddRenderPass<UpdateLastExposureData>("Update Last Exposure", out var passData, ProfilingSampler.Get(HDProfileId.UpdateLastExposure)))
+            {
+                passData.applyExposureCS = defaultResources.shaders.exposureCS;
+                passData.decodeExposureKernel = defaultResources.shaders.exposureCS.FindKernel("KDecodeExposure");
+                passData.exposureBuffer = builder.CreateTransientComputeBuffer(new ComputeBufferDesc(2, sizeof(float)));
+                passData.exposureToDecode = builder.ReadTexture(renderGraph.ImportTexture(GetExposureTexture(hdCamera)));
+                passData.hdCamera = hdCamera;
+
+                builder.SetRenderFunc((UpdateLastExposureData data, RenderGraphContext ctx) =>
+                {
+                    ComputeBuffer buffer = data.exposureBuffer;
+
+                    var cs = data.applyExposureCS;
+                    ctx.cmd.SetComputeTextureParam(cs, data.decodeExposureKernel, HDShaderIDs._InputTexture, data.exposureToDecode);
+                    ctx.cmd.SetComputeBufferParam(cs, data.decodeExposureKernel, HDShaderIDs._OutputExposure, buffer);
+                    ctx.cmd.DispatchCompute(cs, data.decodeExposureKernel, 1, 1, 1);
+
+                    var exposureArray = new float[2];
+                    buffer.GetData(exposureArray);
+
+                    data.hdCamera.lastExposure = exposureArray[1];
+                });
+            }
+        }
+
         #endregion
 
         #region Custom Post Process

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.RenderGraph.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.RenderGraph.cs
@@ -261,6 +261,8 @@ namespace UnityEngine.Rendering.HighDefinition
 
                 TextureHandle postProcessDest = RenderPostProcess(m_RenderGraph, prepassOutput, colorBuffer, backBuffer, cullingResults, hdCamera);
 
+                UpdateCameraLastExposure(m_RenderGraph, hdCamera);
+
                 GenerateDebugImageHistogram(m_RenderGraph, hdCamera, postProcessDest);
                 PushFullScreenExposureDebugTexture(m_RenderGraph, postProcessDest, fullScreenDebugFormat);
 

--- a/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDStringConstants.cs
@@ -791,6 +791,7 @@ namespace UnityEngine.Rendering.HighDefinition
         public static readonly int _InputTexture = Shader.PropertyToID("_InputTexture");
         public static readonly int _InputTextureMSAA = Shader.PropertyToID("_InputTextureMSAA");
         public static readonly int _OutputTexture = Shader.PropertyToID("_OutputTexture");
+        public static readonly int _OutputExposure = Shader.PropertyToID("_OutputExposure");
         public static readonly int _SourceTexture = Shader.PropertyToID("_SourceTexture");
         public static readonly int _InputHistoryTexture = Shader.PropertyToID("_InputHistoryTexture");
         public static readonly int _OutputHistoryTexture = Shader.PropertyToID("_OutputHistoryTexture");

--- a/com.unity.render-pipelines.high-definition/package.json
+++ b/com.unity.render-pipelines.high-definition/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.render-pipelines.high-definition",
   "description": "The High Definition Render Pipeline (HDRP) is a high-fidelity Scriptable Render Pipeline built by Unity to target modern (Compute Shader compatible) platforms. HDRP utilizes Physically-Based Lighting techniques, linear lighting, HDR lighting, and a configurable hybrid Tile/Cluster deferred/Forward lighting architecture and gives you the tools you need to create games, technical demos, animations, and more to a high graphical standard.",
-  "version": "12.1.1-2021.2.2f1-saber.14",
+  "version": "12.1.1-2021.2.2f1-saber.15",
   "unity": "2021.2",
   "displayName": "High Definition RP",
   "dependencies": {


### PR DESCRIPTION
Раскрыл у камеры экспозицию для чтения, чтобы можно было подстраивать яркость источников света по весу экспозиции.