### PR TITLE
MaterialPreprocessor shader replace

### DIFF
--- a/Packages/com.unity.render-pipelines.high-definition/Editor/AssetProcessors/PhysicalMaterial3DsMaxPreprocessor.cs
+++ b/Packages/com.unity.render-pipelines.high-definition/Editor/AssetProcessors/PhysicalMaterial3DsMaxPreprocessor.cs
@@ -15,6 +15,8 @@ namespace UnityEditor.Rendering.HighDefinition
         static readonly int k_Order = -960;
         static readonly string k_ShaderPath = "Packages/com.unity.render-pipelines.high-definition/Runtime/Material/PhysicalMaterial3DsMax/PhysicalMaterial3DsMax.shadergraph";
 
+        private Shader HDRPLit => Shader.Find("HDRP/Lit");
+
         public override uint GetVersion()
         {
             return k_Version;
@@ -55,7 +57,11 @@ namespace UnityEditor.Rendering.HighDefinition
 
             if (Is3DsMaxPhysicalMaterial(description))
             {
-                CreateFrom3DsPhysicalMaterial(description, material, clips);
+                // https://jira.saber3d.net/browse/DCD-2972
+                // Temporary change until Unity fixes the bug.
+                // The bug report has been sent.
+                // CreateFrom3DsPhysicalMaterial(description, material, clips);
+                material.shader = HDRPLit;
             }
             else if (Is3DsMaxSimplifiedPhysicalMaterial(description))
             {

--- a/Packages/com.unity.render-pipelines.high-definition/package.json
+++ b/Packages/com.unity.render-pipelines.high-definition/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.render-pipelines.high-definition",
   "description": "The High Definition Render Pipeline (HDRP) is a high-fidelity Scriptable Render Pipeline built by Unity to target modern (Compute Shader compatible) platforms. HDRP utilizes Physically-Based Lighting techniques, linear lighting, HDR lighting, and a configurable hybrid Tile/Cluster deferred/Forward lighting architecture and gives you the tools you need to create games, technical demos, animations, and more to a high graphical standard.",
-  "version": "13.1.8-2022.1.14f1-saber.21",
+  "version": "13.1.8-2022.1.14f1-saber.22",
   "unity": "2022.1",
   "displayName": "High Definition RP",
   "dependencies": {


### PR DESCRIPTION
https://jira.saber3d.net/browse/DCD-2972
Temporary change until Unity fixes the bug. The bug report has been sent.

PhysicalMaterial3DsMax was changed to HDRP Lit shader to avoid "Property _TRANSPARENCY already exists in the property sheet with a different type" error.